### PR TITLE
Matt/back to on preferences

### DIFF
--- a/src/app/preferences/_components/UpdateUserPreferences/index.tsx
+++ b/src/app/preferences/_components/UpdateUserPreferences/index.tsx
@@ -12,6 +12,7 @@ import { TestIds } from "@/test-ids";
 import { userPreferenceUIString } from "@/uiStrings";
 import { nullableArrayEquals } from "@/util";
 import { Button, Stack, TextField, Typography } from "@mui/material";
+import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import React, { useCallback, useMemo, useState } from "react";
 
@@ -409,16 +410,32 @@ export const UpdateUserPreferences: React.FC<UpdateUserPreferencesProps> = (
               </Typography>
             )}
           </span>
-          <Button
-            type="submit"
-            variant="contained"
-            size="small"
-            data-testid={TestIds.Preferences_SavePreferencesButton}
-            disabled={!api.canSave}
-          >
-            Save
-          </Button>
         </Stack>
+      </Stack>
+      <Stack
+        direction="row"
+        spacing={1}
+        justifyContent={api.backTo ? "space-between" : "flex-end"}
+      >
+        {api.backTo && (
+          <Button
+            LinkComponent={Link}
+            href={api.backTo}
+            color="warning"
+            data-testid={TestIds.Preferences_CancelButton}
+          >
+            Cancel
+          </Button>
+        )}
+        <Button
+          type="submit"
+          variant="contained"
+          size="small"
+          data-testid={TestIds.Preferences_SavePreferencesButton}
+          disabled={!api.canSave}
+        >
+          Save
+        </Button>
       </Stack>
     </form>
   );

--- a/src/components/banner/AuthenticatedUserView.tsx
+++ b/src/components/banner/AuthenticatedUserView.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { handleSignOut } from "@/components/banner/actions";
 import Avatar from "@mui/material/Avatar";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
@@ -9,51 +8,102 @@ import MenuItem from "@mui/material/MenuItem";
 import Typography from "@mui/material/Typography";
 import { User } from "next-auth";
 import Link from "next/link";
-import { useState } from "react";
+import { usePathname } from "next/navigation";
+import { useCallback, useMemo, useState } from "react";
 
 interface AuthenticatedUserViewProps {
   user: User;
 }
 
-export default function AuthenticatedUserView({
-  user,
-}: AuthenticatedUserViewProps) {
+const useAuthenticatedUserViewAPI = (props: AuthenticatedUserViewProps) => {
+  const { user } = props;
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-  const handleClose = () => {
+
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      setAnchorEl(event.currentTarget);
+    },
+    [],
+  );
+
+  const handleClose = useCallback(() => {
     setAnchorEl(null);
+  }, []);
+
+  const handleSignOut = useCallback(async () => {
+    await handleSignOut();
+    setAnchorEl(null);
+  }, []);
+
+  // Backup initials for avatar if image is missing
+  const imageBackup = useMemo(
+    () =>
+      user.name
+        ?.split(" ")
+        .map((a) => a[0])
+        .join("")
+        .toUpperCase() ?? "",
+    [user.name],
+  );
+
+  const pathname = usePathname();
+  const preferencesDisabled = useMemo(
+    () => pathname === "/preferences",
+    [pathname],
+  );
+
+  const preferencesHref = useMemo(() => {
+    if (preferencesDisabled) {
+      return "/preferences";
+    }
+    const searchParams = new URLSearchParams();
+    searchParams.set("backTo", pathname);
+    // TODO: this type of pattern is relatively common, maybe this should also
+    // be supported directly in some of the path functions?
+    return `/preferences?${searchParams.toString()}`;
+  }, [preferencesDisabled, pathname]);
+
+  return {
+    anchorEl,
+    open,
+    handleClick,
+    handleClose,
+    handleSignOut,
+    imageBackup,
+    preferencesHref,
+    preferencesDisabled,
   };
+};
+
+const AuthenticatedUserView: React.FC<AuthenticatedUserViewProps> = (
+  props: AuthenticatedUserViewProps,
+) => {
+  const api = useAuthenticatedUserViewAPI(props);
+  const { user } = props;
 
   return (
     <Box sx={{ display: "flex", alignItems: "center" }}>
       <Button
-        onClick={handleClick}
+        onClick={api.handleClick}
         sx={{ borderRadius: "50%", padding: 0, minWidth: 0 }}
-        aria-controls={open ? "account-menu" : undefined}
+        aria-controls={api.open ? "account-menu" : undefined}
         aria-haspopup="true"
-        aria-expanded={open ? "true" : undefined}
+        aria-expanded={api.open ? "true" : undefined}
       >
         <Avatar
           src={user.image || undefined}
           alt={user.name || "User"}
           sx={{ width: 32, height: 32 }}
         >
-          {user.image === null &&
-            user.name
-              ?.split(" ")
-              .map((a) => a[0])
-              .join("")
-              .toUpperCase()}
+          {user.image === null && api.imageBackup}
         </Avatar>
       </Button>
       <Menu
         id="account-menu"
-        anchorEl={anchorEl}
-        open={open}
-        onClose={handleClose}
+        anchorEl={api.anchorEl}
+        open={api.open}
+        onClose={api.handleClose}
         slotProps={{
           list: { "aria-labelledby": "basic-button" },
         }}
@@ -64,12 +114,7 @@ export default function AuthenticatedUserView({
             alt={user.name || "User"}
             sx={{ width: 56, height: 56, mb: 1 }}
           >
-            {user.image === null &&
-              user.name
-                ?.split(" ")
-                .map((a) => a[0])
-                .join("")
-                .toUpperCase()}
+            {user.image === null && api.imageBackup}
           </Avatar>
           <Box sx={{ display: "flex", flexDirection: "column", ml: 1 }}>
             <Typography variant="subtitle1">{user.name}</Typography>
@@ -78,17 +123,15 @@ export default function AuthenticatedUserView({
         </Box>
         <MenuItem
           component={Link}
-          href="/preferences"
-          onClick={handleClose}
+          href={api.preferencesHref}
+          onClick={api.handleClose}
           sx={{ justifyContent: "right" }}
+          disabled={api.preferencesDisabled}
         >
           Preferences
         </MenuItem>
         <MenuItem
-          onClick={async () => {
-            await handleSignOut();
-            handleClose();
-          }}
+          onClick={api.handleSignOut}
           sx={{ justifyContent: "right", color: "error.main" }}
         >
           Sign out
@@ -96,4 +139,6 @@ export default function AuthenticatedUserView({
       </Menu>
     </Box>
   );
-}
+};
+
+export default AuthenticatedUserView;

--- a/src/test-ids.ts
+++ b/src/test-ids.ts
@@ -25,6 +25,7 @@ export const TestIds = {
   KettlebellPlus: "kettlebell-plus",
   WarmupToggle: "warmup-toggle",
   NotesInput: "notes-input",
+  Preferences_CancelButton: "cancel-user-preferences-button",
   // Add more test IDs here as needed
   EditEquipmentCancelButton: "edit-equipment-cancel-button",
   EditEquipmentResetButton: "edit-equipment-reset-button",

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -33,14 +33,13 @@ console.error = (msg, ...args) => {
   originalError(msg, ...args);
 };
 
-// Mock next/navigation
 vi.mock("next/navigation", () => {
   const actual = vi.importActual("next/navigation");
   return {
     ...actual,
     redirect: vi.fn(),
-    usePathname: vi.fn(), // if you use it
-    useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })), // add replace if you use it
+    usePathname: vi.fn(),
+    useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),
     useSearchParams: vi.fn(() => ({
       get: vi.fn(() => null),
       toString: vi.fn(() => ""),


### PR DESCRIPTION
No beautiful description here, but I did put in some review pointers/direction. 

Implemented functionality where if you go to the preferences page from another page (via the top right user nav thingy), it saves the current page via a searchParam, and then navigates you back there if you click save or the new cancel button

I also disable the preferences link if you're, ya know, on the preferences page. 