### PR TITLE
Matt/testing feat

### DIFF
--- a/integration_tests/add-custom-dumbbell-exercise.integration.test.tsx
+++ b/integration_tests/add-custom-dumbbell-exercise.integration.test.tsx
@@ -4,7 +4,7 @@ import EquipmentExercisePage, {
 import { FIRST_PAGE_NUM, pathForEquipmentExercisePage } from "@/constants";
 import * as serverUtil from "@/serverUtil";
 import { TestIds } from "@/test-ids";
-import { USER_ID_LOGGED_IN } from "@/test/constants";
+import { USER_ID } from "@/test/constants";
 import { getSession, requireLoggedInUser } from "@/test/serverUtil";
 import { getExercisesByEquipment } from "@/util";
 import { act, render, screen, waitFor } from "@testing-library/react";
@@ -23,16 +23,22 @@ const exercisesByEquipment = getExercisesByEquipment();
 beforeEach(async () => {
   vi.restoreAllMocks();
   vi.spyOn(serverUtil, "requireLoggedInUser").mockImplementation(
-    requireLoggedInUser(USER_ID_LOGGED_IN),
+    requireLoggedInUser(
+      USER_ID["add-custom-dumbbell-exercise.integration.test.tsx"],
+    ),
   );
   vi.spyOn(serverUtil, "getSession").mockImplementation(
-    getSession(USER_ID_LOGGED_IN),
+    getSession(USER_ID["add-custom-dumbbell-exercise.integration.test.tsx"]),
   );
-  await deleteRelevantRowsForUser(USER_ID_LOGGED_IN);
+  await deleteRelevantRowsForUser(
+    USER_ID["add-custom-dumbbell-exercise.integration.test.tsx"],
+  );
 });
 
 afterEach(async () => {
-  await deleteRelevantRowsForUser(USER_ID_LOGGED_IN);
+  await deleteRelevantRowsForUser(
+    USER_ID["add-custom-dumbbell-exercise.integration.test.tsx"],
+  );
 });
 
 // TODO: Consider a test for the "real" page that does fancy narrowing, etc.
@@ -40,7 +46,7 @@ afterEach(async () => {
 describe("User Journey: Add Custom Dumbbell Exercises", () => {
   it("should allow a logged in user to add a custom curl dumbbell exercise", async () => {
     const pageProps: EquipmentExercisePageProps = {
-      userId: USER_ID_LOGGED_IN,
+      userId: USER_ID["add-custom-dumbbell-exercise.integration.test.tsx"],
       equipmentType: "dumbbell",
       exerciseType: "dumbbell_bicep_curl",
       path: pathForEquipmentExercisePage("dumbbell", "dumbbell_bicep_curl"),
@@ -57,7 +63,10 @@ describe("User Journey: Add Custom Dumbbell Exercises", () => {
       const { data: initialCurls } = await supabase
         .from("exercises")
         .select("*")
-        .eq("user_id", USER_ID_LOGGED_IN)
+        .eq(
+          "user_id",
+          USER_ID["add-custom-dumbbell-exercise.integration.test.tsx"],
+        )
         .eq("exercise_type", "dumbbell_bicep_curl");
       expect(initialCurls?.length).toBe(0);
       const addExerciseButton = await waitFor(() =>
@@ -74,7 +83,10 @@ describe("User Journey: Add Custom Dumbbell Exercises", () => {
         const { data: drafts } = await supabase
           .from("form_drafts")
           .select("*")
-          .eq("user_id", USER_ID_LOGGED_IN);
+          .eq(
+            "user_id",
+            USER_ID["add-custom-dumbbell-exercise.integration.test.tsx"],
+          );
         expect(drafts?.length).toBeGreaterThan(0);
       });
       page = await EquipmentExercisePage(pageProps);
@@ -96,7 +108,10 @@ describe("User Journey: Add Custom Dumbbell Exercises", () => {
         const { data: lifts } = await supabase
           .from("exercises")
           .select("*")
-          .eq("user_id", USER_ID_LOGGED_IN)
+          .eq(
+            "user_id",
+            USER_ID["add-custom-dumbbell-exercise.integration.test.tsx"],
+          )
           .eq("exercise_type", "dumbbell_bicep_curl");
         expect(lifts?.length).toBe(1);
         expect(lifts![0].completion_status).toBe("completed");

--- a/integration_tests/add-wendler-block.integration.test.tsx
+++ b/integration_tests/add-wendler-block.integration.test.tsx
@@ -1,5 +1,5 @@
 import * as serverUtil from "@/serverUtil";
-import { USER_ID_LOGGED_IN } from "@/test/constants";
+import { USER_ID } from "@/test/constants";
 import { getSession, requireLoggedInUser } from "@/test/serverUtil";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -12,12 +12,14 @@ const deleteAllExercisesForUser = async (userId: string) => {
 beforeEach(async () => {
   vi.restoreAllMocks();
   vi.spyOn(serverUtil, "requireLoggedInUser").mockImplementation(
-    requireLoggedInUser(USER_ID_LOGGED_IN),
+    requireLoggedInUser(USER_ID["add-wendler-block.integration.test.tsx"]),
   );
   vi.spyOn(serverUtil, "getSession").mockImplementation(
-    getSession(USER_ID_LOGGED_IN),
+    getSession(USER_ID["add-wendler-block.integration.test.tsx"]),
   );
-  await deleteAllExercisesForUser(USER_ID_LOGGED_IN);
+  await deleteAllExercisesForUser(
+    USER_ID["add-wendler-block.integration.test.tsx"],
+  );
 });
 
 // TODO - actually add in some tests here.

--- a/integration_tests/preferences.integration.test.tsx
+++ b/integration_tests/preferences.integration.test.tsx
@@ -3,7 +3,7 @@ import { DEFAULT_VALUES } from "@/constants";
 import * as serverUtil from "@/serverUtil";
 import { supabaseRPC } from "@/serverUtil";
 import { TestIds } from "@/test-ids";
-import { USER_ID_PREFERENCES } from "@/test/constants";
+import { USER_ID } from "@/test/constants";
 import { getSession, requireLoggedInUser } from "@/test/serverUtil";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -17,16 +17,16 @@ const deleteRelevantRowsForUser = async (userId: string) => {
 beforeEach(async () => {
   vi.restoreAllMocks();
   vi.spyOn(serverUtil, "requireLoggedInUser").mockImplementation(
-    requireLoggedInUser(USER_ID_PREFERENCES),
+    requireLoggedInUser(USER_ID["preferences.integration.test.tsx"]),
   );
   vi.spyOn(serverUtil, "getSession").mockImplementation(
-    getSession(USER_ID_PREFERENCES),
+    getSession(USER_ID["preferences.integration.test.tsx"]),
   );
-  await deleteRelevantRowsForUser(USER_ID_PREFERENCES);
+  await deleteRelevantRowsForUser(USER_ID["preferences.integration.test.tsx"]);
 });
 
 afterEach(async () => {
-  await deleteRelevantRowsForUser(USER_ID_PREFERENCES);
+  await deleteRelevantRowsForUser(USER_ID["preferences.integration.test.tsx"]);
 });
 
 describe("User Journey: Update Preferences", () => {
@@ -39,7 +39,7 @@ describe("User Journey: Update Preferences", () => {
     const { data: initialPrefs } = await supabase
       .from("user_preferences")
       .select("*")
-      .eq("user_id", USER_ID_PREFERENCES);
+      .eq("user_id", USER_ID["preferences.integration.test.tsx"]);
     expect(initialPrefs?.length).toBe(0);
 
     // Find and click the "Save Preferences" button.
@@ -54,7 +54,7 @@ describe("User Journey: Update Preferences", () => {
         const { data: prefs } = await supabase
           .from("user_preferences")
           .select("*")
-          .eq("user_id", USER_ID_PREFERENCES);
+          .eq("user_id", USER_ID["preferences.integration.test.tsx"]);
         expect(prefs?.length).toBeGreaterThan(0);
       });
     });
@@ -62,7 +62,7 @@ describe("User Journey: Update Preferences", () => {
     // Assert the default settings were saved correctly.
     await waitFor(async () => {
       const preferences = await supabaseRPC("get_user_preferences", {
-        p_user_id: USER_ID_PREFERENCES,
+        p_user_id: USER_ID["preferences.integration.test.tsx"],
       });
       expect(preferences.available_dumbbells_lbs).toEqual(
         DEFAULT_VALUES.AVAILABLE_DUMBBELLS_LBS,

--- a/src/app/exercise-block/[exercise_block_id]/_components/WendlerBlockRowActive.tsx
+++ b/src/app/exercise-block/[exercise_block_id]/_components/WendlerBlockRowActive.tsx
@@ -68,10 +68,6 @@ const useWendlerBlockRowActiveAPI = (props: WendlerBlockRowActiveProps) => {
     [],
   );
 
-  const onTargetWeightChange = React.useCallback((newWeight: number) => {
-    setTargetWeight(newWeight);
-  }, []);
-
   const modifiedRow = React.useMemo(() => {
     return {
       ...row,
@@ -97,7 +93,7 @@ const useWendlerBlockRowActiveAPI = (props: WendlerBlockRowActiveProps) => {
     onCompletionStatusChange,
     onNotesChange,
     onEffortChange: onPerceivedEffortChange,
-    onTargetWeightChange,
+    onTargetWeightChange: setTargetWeight,
     modifiedRow,
     editable,
     handleClickWeight,

--- a/src/app/exercise/[equipment_type]/[exercise_type]/_components/AddEquipmentExercise/index.tsx
+++ b/src/app/exercise/[equipment_type]/[exercise_type]/_components/AddEquipmentExercise/index.tsx
@@ -50,8 +50,9 @@ const AddEquipmentExercise: React.FC<AddEquipmentExerciseProps> = (props) => {
         <SelectReps
           reps={api.reps}
           onRepsChange={(reps: number) => api.setReps(reps)}
-          // TODO: re-update this to properly support amrap.
           isAmrap={api.isAmrap}
+          // TODO: cleanup for later, rename Amrap to AMRAP
+          setIsAmrap={api.setIsAMRAP}
         />
         <Stack
           direction="row"

--- a/src/app/exercise/[equipment_type]/[exercise_type]/edit/[exercise_id]/_components/EditBarbellExercise/index.tsx
+++ b/src/app/exercise/[equipment_type]/[exercise_type]/edit/[exercise_id]/_components/EditBarbellExercise/index.tsx
@@ -45,13 +45,6 @@ const useEditBarbellExerciseAPI = (props: EditBarbellExerciseProps) => {
   );
   const [notes, setNotes] = React.useState(props.exercise.notes ?? "");
 
-  const onLocalTargetWeightChange = React.useCallback(
-    (newTargetWeight: number) => {
-      setLocalTargetWeight(newTargetWeight);
-    },
-    [],
-  );
-
   const onLocalRepsChange = React.useCallback((newReps: number) => {
     setLocalReps(newReps);
   }, []);
@@ -101,7 +94,7 @@ const useEditBarbellExerciseAPI = (props: EditBarbellExerciseProps) => {
 
   return {
     targetWeight: localTargetWeight,
-    onTargetWeightWeightChange: onLocalTargetWeightChange,
+    onTargetWeightWeightChange: setLocalTargetWeight,
     reps: localReps,
     onRepsChange: onLocalRepsChange,
     completionStatus,

--- a/src/components/edit/EditBarbell.tsx
+++ b/src/components/edit/EditBarbell.tsx
@@ -12,7 +12,7 @@ export interface EditBarbellProps {
   roundingMode: RoundingMode;
   // TODO: rename to barbellWeightValue
   barWeight: number;
-  onTargetWeightChange: (newTargetWeight: number) => void;
+  onTargetWeightChange: React.Dispatch<React.SetStateAction<number>>;
   weightUnit: WeightUnit;
   availablePlates: number[];
   editing?: boolean;
@@ -55,7 +55,7 @@ const useEditBarbellAPI = (props: EditBarbellProps) => {
   const handleAdd = React.useCallback(
     (increment: number) => {
       setTargetWeightHistory((prev) => prev.push(targetWeight));
-      onTargetWeightChange(targetWeight + increment * 2);
+      onTargetWeightChange((prevWeight) => prevWeight + increment * 2);
     },
     [onTargetWeightChange, targetWeight],
   );

--- a/src/components/edit/EditNotes.tsx
+++ b/src/components/edit/EditNotes.tsx
@@ -1,4 +1,5 @@
 import { useRequiredModifiableLabel } from "@/hooks";
+import { TestIds } from "@/test-ids";
 import ClearIcon from "@mui/icons-material/Clear";
 import { IconButton, TextField } from "@mui/material";
 import React from "react";
@@ -34,6 +35,9 @@ const EditNotes: React.FC<EditNotesProps> = (props) => {
       onChange={(e) => api.onNotesChange(e.target.value)}
       required={props.isRequired}
       slotProps={{
+        htmlInput: {
+          "data-testid": TestIds.NotesInput,
+        },
         input: {
           endAdornment: (
             <IconButton

--- a/src/components/select/SelectActivePlates.tsx
+++ b/src/components/select/SelectActivePlates.tsx
@@ -111,11 +111,14 @@ const SelectActivePlates: React.FC<SelectActivePlatesProps> = (props) => {
               <Badge
                 key={plate}
                 sx={metadata?.sx}
-                data-testid={metadata?.testid}
                 badgeContent={count > 0 ? count : undefined}
                 anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
               >
-                <Button size="small" onClick={() => api.onAddPlate(plate)}>
+                <Button
+                  data-testid={metadata?.testid}
+                  size="small"
+                  onClick={() => api.onAddPlate(plate)}
+                >
                   {fractionWeightFormat(plate)}
                 </Button>
               </Badge>

--- a/src/components/select/SelectPerceivedEffort.tsx
+++ b/src/components/select/SelectPerceivedEffort.tsx
@@ -1,6 +1,7 @@
 import { PerceivedEffort } from "@/common-types";
 import DisplayPerceivedEffort from "@/components/display/DisplayPerceivedEffort";
 import { Constants } from "@/database.types";
+import { TestIds } from "@/test-ids";
 import { perceivedEffortUIString } from "@/uiStrings";
 import {
   FormControl,
@@ -54,6 +55,7 @@ const SelectPerceivedEffort = (props: SelectPerceivedEffortProps) => {
       >
         {Constants.public.Enums.perceived_effort_enum.map((effort) => (
           <ToggleButton
+            data-testid={TestIds.PerceivedEffort(effort)}
             key={effort}
             value={effort}
             aria-label={perceivedEffortUIString(effort)}

--- a/src/components/select/SelectReps/index.tsx
+++ b/src/components/select/SelectReps/index.tsx
@@ -1,4 +1,10 @@
-import { ToggleButton, ToggleButtonGroup, Typography } from "@mui/material";
+import { TestIds } from "@/test-ids";
+import {
+  Stack,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography,
+} from "@mui/material";
 import FormControl from "@mui/material/FormControl";
 import FormLabel from "@mui/material/FormLabel";
 import React, { useMemo } from "react";
@@ -9,6 +15,7 @@ export interface SelectRepsProps {
   repChoices?: number[];
   wendlerReps?: boolean;
   isAmrap?: boolean;
+  setIsAmrap?: (isAmrap: boolean) => void;
   hideSettings?: boolean;
 }
 
@@ -58,13 +65,6 @@ function useSelectRepsAPI(props: SelectRepsProps) {
   };
 }
 
-// TODO - Consider updating this where the current rep choice always has a
-// button, even if it's not in the choices. It doesn't need to stay, but it'll
-// make it easier to see what the current rep number is.
-//
-// Thinking about this more, it may be annoying because it may cause the UI to
-// bump around?
-
 const SelectReps: React.FC<SelectRepsProps> = (props) => {
   const api = useSelectRepsAPI(props);
 
@@ -73,42 +73,67 @@ const SelectReps: React.FC<SelectRepsProps> = (props) => {
       <FormLabel sx={{ display: "flex", alignItems: "center", gap: 1 }}>
         Reps: {props.reps}
         {props.isAmrap && (
-          <Typography variant="body2" color="primary">
+          <Typography variant="body2" color="secondary">
             (AMRAP)
           </Typography>
         )}
       </FormLabel>
-      <ToggleButtonGroup
-        color="primary"
-        value={props.reps}
-        exclusive
-        onChange={api.handleToggleChange}
-        size="small"
-        aria-label="Select Reps"
-        sx={{ mb: 1 }}
-      >
-        <ToggleButton
-          value="-"
-          disabled={api.isDecrementDisabled}
-          aria-label="decrement reps"
+      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+        <ToggleButtonGroup
+          color="secondary"
+          value={props.isAmrap}
+          exclusive
+          onChange={(_, newValue) => {
+            props.setIsAmrap?.(newValue);
+          }}
           size="small"
+          aria-label="toggle AMRAP"
         >
-          -
-        </ToggleButton>
-        {api.choices.map((val) => (
           <ToggleButton
-            key={val}
-            value={val}
-            aria-label={`reps ${val}`}
+            size="small"
+            value={true}
+            aria-label="toggle AMRAP"
+            data-testid={TestIds.SelectRepsAMRAPToggle}
+          >
+            AMRAP
+          </ToggleButton>
+        </ToggleButtonGroup>
+        <ToggleButtonGroup
+          color="primary"
+          value={props.reps}
+          exclusive
+          onChange={api.handleToggleChange}
+          size="small"
+          aria-label="Select Reps"
+        >
+          <ToggleButton
+            value="-"
+            disabled={api.isDecrementDisabled}
+            aria-label="decrement reps"
             size="small"
           >
-            {val}
+            -
           </ToggleButton>
-        ))}
-        <ToggleButton value="+" aria-label="increment reps" size="small">
-          +
-        </ToggleButton>
-      </ToggleButtonGroup>
+          {api.choices.map((val) => (
+            <ToggleButton
+              key={val}
+              value={val}
+              aria-label={`reps ${val}`}
+              size="small"
+            >
+              {val}
+            </ToggleButton>
+          ))}
+          <ToggleButton
+            data-testid={TestIds.SelectRepsAdd}
+            value="+"
+            aria-label="increment reps"
+            size="small"
+          >
+            +
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Stack>
     </FormControl>
   );
 };

--- a/src/components/select/SelectWarmup.tsx
+++ b/src/components/select/SelectWarmup.tsx
@@ -1,3 +1,4 @@
+import { TestIds } from "@/test-ids";
 import { Checkbox, FormControlLabel } from "@mui/material";
 import React from "react";
 
@@ -30,6 +31,7 @@ const SelectWarmup: React.FC<SelectWarmupProps> = (props) => {
     <FormControlLabel
       control={
         <Checkbox
+          data-testid={TestIds.WarmupToggle}
           checked={api.isWarmup}
           onChange={api.onToggle}
           color="primary"

--- a/src/test-ids.ts
+++ b/src/test-ids.ts
@@ -1,5 +1,7 @@
 "use client";
 
+import { PerceivedEffort } from "@/common-types";
+
 /**
  * Test IDs for use in data-testid attributes throughout the app.
  * Use these to avoid accidental collisions and to keep test selectors consistent.
@@ -16,5 +18,9 @@ export const TestIds = {
   addWendlerLegDayButton: "add-wendler-leg-day-button",
   // PreferencesPage test IDs
   Preferences_SavePreferencesButton: "save-user-preferences-button",
-  // Add more test IDs here as needed
+  SelectRepsAMRAPToggle: "select-reps-amrap-toggle",
+  SelectRepsAdd: "select-reps-add-1",
+  PerceivedEffort: (effort: PerceivedEffort) => `perceived-effort-${effort}`,
+  WarmupToggle: "warmup-toggle",
+  NotesInput: "notes-input",
 } as const;

--- a/src/test/constants.ts
+++ b/src/test/constants.ts
@@ -2,5 +2,26 @@
 // Stryker disable all
 // This file is ignored by coverage and mutation testing tools.
 
-export const USER_ID_LOGGED_IN = "00000000-0000-0000-0000-000000000001";
-export const USER_ID_PREFERENCES = "00000000-0000-0000-0000-000000000004";
+// Because vitest runs tests in parallel, we should use a different user ID for
+// each test file. This is only done by convention and not enforced in any way.
+// If you think you've found some flakey tests, check that the user ID being
+// used is actually unique for that test file.
+
+export const USER_ID = {
+  "personal_record_test@example.com": "00000000-0000-0000-0000-000000000002",
+  "fullyseeded@example.com": "00000000-0000-0000-0000-000000000003",
+  "user_preferences_test@example.com": "00000000-0000-0000-0000-000000000004",
+  "personal_record_user_1@example.com": "aaaaaaaa-bbbb-cccc-dddd-000000000001",
+  "add-custom-barbell-exercise.integration.test.tsx":
+    "00000000-0000-0000-0001-000000000000",
+  "add-custom-dumbbell-exercise.integration.test.tsx":
+    "00000000-0000-0000-0001-000000000001",
+  "add-wendler-block.integration.test.tsx":
+    "00000000-0000-0000-0001-000000000002",
+  "preferences.integration.test.tsx": "00000000-0000-0000-0001-000000000003",
+};
+
+const SET_OF_IDS = new Set(Object.values(USER_ID));
+if (SET_OF_IDS.size !== Object.values(USER_ID).length) {
+  throw new Error("Duplicate user IDs found, fix this.");
+}

--- a/supabase/migrations/00000000040280_create_test_user.sql
+++ b/supabase/migrations/00000000040280_create_test_user.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE FUNCTION _system.create_test_user (
+  p_id uuid,
+  p_email text,
+  p_create_preferences boolean
+) RETURNS void AS $$
+BEGIN
+  INSERT INTO next_auth.users (id, name, email, "emailVerified", image)
+  VALUES (p_id, p_email, p_email, NOW(), 'https://example.com/avatar.png');
+
+  IF p_create_preferences THEN
+    PERFORM public.set_user_preferences (
+      p_user_id => p_id,
+      p_preferred_weight_unit => 'pounds',
+      p_default_rest_time => 120,
+      p_available_plates_lbs => ARRAY[45, 35, 25, 10, 5, 2.5]::numeric[],
+      p_available_dumbbells_lbs => ARRAY[50, 40, 30, 20, 10]::numeric[]
+    );
+  END IF;
+END;
+$$ LANGUAGE plpgsql;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,79 +1,69 @@
 -- Start test seed data.
--- Example seed user for testing
-INSERT INTO
-  next_auth.users (id, name, email, "emailVerified", image)
-VALUES
-  (
-    '00000000-0000-0000-0000-000000000001',
-    'Test User',
-    'testuser@example.com',
-    NOW(),
-    'https://example.com/avatar.png'
-  )
-ON CONFLICT (id) DO NOTHING;
-
--- Insert user metadata for the test user. This is needed so we don't always
--- redirect within the unit tests which isn't really supported since it has to
--- throw to redirect.
 SELECT
-  public.set_user_preferences (
-    p_user_id => '00000000-0000-0000-0000-000000000001'::uuid,
-    p_preferred_weight_unit => 'pounds'::weight_unit_enum,
-    p_default_rest_time => 120,
-    p_available_plates_lbs => ARRAY[45, 35, 25, 10, 5, 2.5]::numeric[],
-    p_available_dumbbells_lbs => ARRAY[50, 40, 30, 20, 10]::numeric[]
+  _system.create_test_user (
+    p_email => 'testuser@example.com',
+    p_id => '00000000-0000-0000-0000-000000000001'::uuid,
+    p_create_preferences => true
   );
 
 -- Additional seed user for update_user_personal_record tests
-INSERT INTO
-  next_auth.users (id, name, email, "emailVerified", image)
-VALUES
-  (
-    '00000000-0000-0000-0000-000000000002',
-    'PR Test User',
-    'personal_record_test@example.com',
-    NOW(),
-    'https://example.com/avatar2.png'
-  )
-ON CONFLICT (id) DO NOTHING;
+SELECT
+  _system.create_test_user (
+    p_email => 'personal_record_test@example.com',
+    p_id => '00000000-0000-0000-0000-000000000002'::uuid,
+    p_create_preferences => true
+  );
 
 -- Fully seeded user for integration/analytics tests
-INSERT INTO
-  next_auth.users (id, name, email, "emailVerified", image)
-VALUES
-  (
-    '00000000-0000-0000-0000-000000000003',
-    'Fully Seeded User',
-    'fullyseeded@example.com',
-    NOW(),
-    'https://example.com/avatar3.png'
-  )
-ON CONFLICT (id) DO NOTHING;
+SELECT
+  _system.create_test_user (
+    p_email => 'fullyseeded@example.com',
+    p_id => '00000000-0000-0000-0000-000000000003'::uuid,
+    p_create_preferences => true
+  );
 
 -- Additional seed user for update_user_personal_record tests
-INSERT INTO
-  next_auth.users (id, name, email, "emailVerified", image)
-VALUES
-  (
-    '00000000-0000-0000-0000-000000000004',
-    'User Preferences Test User',
-    'user_preferences_test@example.com',
-    NOW(),
-    'https://example.com/avatar4.png'
-  )
-ON CONFLICT (id) DO NOTHING;
+SELECT
+  _system.create_test_user (
+    p_email => 'user_preferences_test@example.com',
+    p_id => '00000000-0000-0000-0000-000000000004'::uuid,
+    p_create_preferences => true
+  );
 
-INSERT INTO
-  next_auth.users (id, name, email, "emailVerified", image)
-VALUES
-  (
-    'aaaaaaaa-bbbb-cccc-dddd-000000000001',
-    'Personal Record User 1',
-    'personal_record_user_1@example.com',
-    now(),
-    'https://example.com/avatar1.png'
-  )
-ON CONFLICT (id) DO NOTHING;
+SELECT
+  _system.create_test_user (
+    p_email => 'personal_record_user_1@example.com',
+    p_id => 'aaaaaaaa-bbbb-cccc-dddd-000000000001'::uuid,
+    p_create_preferences => true
+  );
+
+SELECT
+  _system.create_test_user (
+    p_email => 'add-custom-barbell-exercise.integration.test.tsx',
+    p_id => '00000000-0000-0000-0001-000000000000'::uuid,
+    p_create_preferences => true
+  );
+
+SELECT
+  _system.create_test_user (
+    p_email => 'add-custom-dumbbell-exercise.integration.test.tsx',
+    p_id => '00000000-0000-0000-0001-000000000001'::uuid,
+    p_create_preferences => true
+  );
+
+SELECT
+  _system.create_test_user (
+    p_email => 'add-wendler-block.integration.test.tsx',
+    p_id => '00000000-0000-0000-0001-000000000002'::uuid,
+    p_create_preferences => true
+  );
+
+SELECT
+  _system.create_test_user (
+    p_email => 'preferences.integration.test.tsx',
+    p_id => '00000000-0000-0000-0001-000000000003'::uuid,
+    p_create_preferences => true
+  );
 
 -- Note: Matt & Steph users are NOT created here - they will be created automatically
 -- when they sign up through NextAuth, thanks to the get_deterministic_uuid() function


### PR DESCRIPTION
# Pull Request: Improve Testing and Standardize Test-User Creation

## Summary

This PR improves testing a bit by making sure you can modify all of the default
controls that are visible when adding a barbell exercise. Initially, the goal of
this was just to add additional functionality via the new AMRAP toggle, but
everything grows when you try to do something simple.

As I worked on testing the AMRAP toggle, I stumbled on a bug that was the result
of the `add-custom-barbell-exercise.integration.test.tsx` using the same user Id
as the `add-custom-barbell-exercise.integration.test.tsx`. The issue was that
the tests all share a db instance (the one running in a local container) and it
introduced flakiness since they were both trying to write exercises for the same
user. Of course I couldn't simply fix that but ended up fully refactoring how
we set up test users in the first place.

The good news is that it's now easier to set up test users so we can have a
different user for ever integration test, the bad news is that you're reading
all of this now and trying to decide if it's still worth it to work on this
project with me if this is how PRs always go lol.

## Key Changes

### Standardized Test User IDs

- Replaced user ids in all integration tests with a new `USER_ID`
  mapping in `src/test/constants.ts`.
- Each test file now uses a unique test user, preventing cross-test
  contamination and flakiness due to parallel test execution.
- Added a runtime check to ensure all test user IDs are unique.
  - Note: this only actually does anything in test since that's the only time
    these files are imported.

### 2. Database Seeding and Migration

- Added a new migration: `_system.create_test_user` whech creates a stored
  procedure for, you guessed it, creating test users.
- Updated `supabase/seed.sql` to use this procedure for all test users.
- Additionally added in new, clearly named, test users for each integration
  test.
  - Note: we will need to add more in the future.

### UI Component Testability

- Added `data-testid` attributes to UI components used in the barbell add page
  (`EditNotes`, `SelectActivePlates`, `SelectPerceivedEffort`, `SelectReps`, and
  `SelectWarmup`) so we can click (and in the case, of notes, change the input) and assert that something actually happens as a result.

### Component and Hook API Consistency

- Refactored relevant component APIs (I think it was actually just the
  setTargetWeight one in a parent hook) to use
  `React.Dispatch<React.SetStateAction<T>>` for state setters.
  - Note: This wasn't just for the meme, there was actually a bug where if you
    clicked to quickly (though proabbly like "I am a computer" too quickly) only
    the last update would go through because of how hooks and stuff work.
    Switching to the setStateAction one meant that we could use the function form
    which, for _REASONS_, doesn't have an issue with super frequent updates.

### Expanded Test Coverage

- Added a new integration test to verify that all UI fields can be modified and
  saved correctly for a dumbbell exercise.

## Why Unrelated Files Changed

- **Component APIs and Test IDs:** In order to easily select components in test,
  several UI components were updated to expose `data-testid` attributes .
- **Database Seed/Migration:** The new test user creation procedure required
  updates to both migration and seed files. Technically I probably could have
  skipped this but it was shiny.
- **Test Constants:** Refactoring to use a mapping for user IDs required changes
  to all test files and supporting constants (i.e. they had to use the new
  mapping I set up or it kinda defeated the purpose).

I hope you read this because while it started with an AI prompt, I promise I
edited almost every word lol.
